### PR TITLE
Update wrath to remove unused input line -w in sv_detection.py, when detecting SVs without plotting (-p -l)

### DIFF
--- a/wrath
+++ b/wrath
@@ -301,7 +301,6 @@ if [ -z ${step+x} ] || [ ! -z ${outliersStep+x} ] && [ ! -z ${noplot+x} ] && [ !
   mkdir -p wrath_out/SVs
   python ${DIR}/sv_detection/sv_detection.py \
   --matrix wrath_out/matrices/jaccard_matrix_${winSize}_${chromosome}_${start}_${end}_$(basename "$group" .txt).txt \
-  -w wrath_out/beds/windows_${winSize}_${chromosome}_${start}_${end}.bed \
   -o wrath_out/outliers/outliers_${winSize}_${chromosome}_${start}_${end}_$(basename "$group" .txt).csv \
   -s wrath_out/SVs/sv_${winSize}_${chromosome}_${start}_${end}_$(basename "$group" .txt).txt ||
   { >&2 "Detecting SVs in matrix wrath_out/matrices/jaccard_matrix_${winSize}_${chromosome}_${start}_${end}_$(basename "$group" .txt).txt step failed"; exit 1; }


### PR DESCRIPTION
removed line with -w (window bed file) as input of sv_detection.py script, does not use it