### PR TITLE
Update sv_detection_and_heatmap.py so that output table has chromosomal positions

### DIFF
--- a/sv_detection/sv_detection_and_heatmap.py
+++ b/sv_detection/sv_detection_and_heatmap.py
@@ -6,6 +6,7 @@
 #        window_size = size of genomic windows
 #        chromosome = chromosome name
 #        window_file = file with genomic window positions
+#        start = start position for region within chromosome
 # Output: output_file = list of SVs with start and end positions and length in genomic windows
 #         plot_file = heatmap plot
 # Modules required: argparse, pandas, numpy, matplotlib, seaborn, sklearn
@@ -34,6 +35,7 @@ parser.add_argument("-s", "--outFile", help="Output SVs", action = "store")
 parser.add_argument("-f", "--winSize", help="Window size", type=int, action = "store", default = 1)
 parser.add_argument("-c", "--chromosome", help="Chromosome name", type=str, action = "store")
 parser.add_argument("-w", "--windowFile", help="Input genomic windows file", action = "store")
+parser.add_argument("-a", "--start", help="Start position to subset windows within chromosome", type=int, action = "store")
 
 args = parser.parse_args()
 
@@ -49,6 +51,7 @@ outplot = args.plot
 output = args.outFile
 window_size = args.winSize
 chrom = args.chromosome
+start = args.start
 
 
 #########################################################################################################################
@@ -121,6 +124,7 @@ fig.savefig(outplot)
 breakPoints['length']=breakPoints['maxcol']-breakPoints['minrow']
 breakPoints.sort_values(by=['length'], ascending=False, inplace=True)
 
-output_table={'SV_id':breakPoints.index.values, 'chromosome':chrom, 'start':breakPoints['minrow']*window_size, 'end':breakPoints['maxcol']*window_size, 'length':breakPoints['length']*window_size}
+# create SV detection table and add chromosome start (-a) positions to obtain chromosome position (bp)
+output_table={'SV_id':breakPoints.index.values, 'chromosome':chrom, 'start':breakPoints['minrow']*window_size+start, 'end':breakPoints['maxcol']*window_size+start, 'length':breakPoints['length']*window_size}
 output_df=pd.DataFrame(output_table)
 output_df.to_csv(output,index=False)


### PR DESCRIPTION
Update sv_detection_and_heatmap.py so that automatically detected SV start/end positions in the output table represent chromosomal positions (bp), rather than positions within the region under study (current format). 

For that, -a start positions need to be read in, and then added to the position within region.

Equivalent to request for sv_detection.py https://github.com/annaorteu/wrath/pull/6/commits/c0d46cd7a13819285ee5b4dfd3a2d0471e7394e8

Requires changes in main wrath script, as requested https://github.com/annaorteu/wrath/pull/5