### PR TITLE
Update wrath to allow for species with integer chromosome names

### DIFF
--- a/wrath
+++ b/wrath
@@ -195,9 +195,9 @@ if [ -z ${step+x} ] || [ ! -z ${getbarcodes+x} ]; then
     do
     echo "Getting ${sample} barcodes from ${chromosome}"
     samtools view -q 20 -@ ${threads} ${sample} ${chromosome}:${start}-${end} |
-    grep -o -P "${chromosome}.*BX:Z:[^\t\n]*" |
-    awk '{print $1"\t"$2"\t"$2"\t"$NF}' > wrath_out/beds/barcodes_${chromosome}_${start}_${end}_$(basename "$group" .txt)_$(basename $sample .bam).bed
-  done || { >&2 echo "Getting ${sample} barcodes from ${chromosome} failed" ; exit 1; }
+    grep -o -P ".*BX:Z:[^\t\n]*" |
+    awk '{print $3"\t"$4"\t"$4"\t"$NF}' > wrath_out/beds/barcodes_${chromosome}_${start}_${end}_$(basename "$group" .txt)_$(basename $sample .bam).bed
+done || { >&2 echo "Getting ${sample} barcodes from ${chromosome} failed" ; exit 1; }
 
   #sort barcodes
   echo "Sorting of $(basename "$group" .txt) barcodes bed files from ${chromosome}"


### PR DESCRIPTION
Wrath fails at jaccard matrix step because BX tag extraction done incorrectly when species reference genome has chromosome names that are just numbers (e.g. 1 - 31) as opposed to characters+ numbers (e.g. Herato0204).

To extract barcodes, wrath was using grep to first find the chromosome column in the bam files and keep everything after that match up until the BX tag -> grep -o -P "${chromosome}.*BX:Z:[^\t\n]*" . However, if "chromosome" is a number, the match might occur in the QNAME field (first field of a bam file), and then the barcode extraction would pick up the wrong columns.

Changed so that grep takes everything before the BX tag field, and then awk only takes the relevant columns (chr , pos, pos, bx tag). This should be generalisable as long as bam files all have the same format (third field= RNAME), no matter the chromosome name format